### PR TITLE
Minor Bugfix for newEvent Route

### DIFF
--- a/api/src/main/java/com/events/Event.java
+++ b/api/src/main/java/com/events/Event.java
@@ -23,7 +23,7 @@ public class Event {
     private Date time;
     private String location;
     private int ownerId;
-    private EventStatus status;
+    private EventStatus status = EventStatus.UPCOMMING;
 
 
     @OneToMany(mappedBy = "event")


### PR DESCRIPTION
New Event was throwing a nullpointer exception when status was not provided.
The default will be overwritten by the value in the DB